### PR TITLE
Properly handle ex cmds with capital letters

### DIFF
--- a/vimlint/ex.py
+++ b/vimlint/ex.py
@@ -166,14 +166,14 @@ def expand(excmd):
                     exaliases[current] = complete
                     current += ch
 
-    return exaliases.get(excmd.lower(), None)
+    return exaliases.get(excmd, None)
 
 
 def linecmd(line):
     try:
-        cmd = re.match('\s*:*%?([a-z]+|!)', line).group(1)
+        cmd = re.match('\s*:*%?(([a-z][a-zA-Z]*)|!)', line).group(1)
         expanded = expand(cmd)
-        return expanded if expanded else cmd.lower()
+        return expanded if expanded else cmd
     except:
         pass
 


### PR DESCRIPTION
ex commands can have capital letters after their first character
linecmd's regex should capture this.
Also, functions should not call lower() on a command as it's
case-sensitive.

For example, before the change: cNext and cNexttttt both are captured as "c" which expands to "change" and we see no error.
