### PR TITLE
Fix bangline

### DIFF
--- a/vimlint/vimlint.py
+++ b/vimlint/vimlint.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Vim Lint
 # Author:       Daan Bakker
 # HomePage:     http://github.com/dbakker/vim-lint


### PR DESCRIPTION
The missing bangline causes errors unless you invoke it with `python vimlint/vimlint.py`.

This change allows invoking it using only `./vimlint/vimlint.py`.